### PR TITLE
Catch no schema and throw useful error

### DIFF
--- a/athena_cli.py
+++ b/athena_cli.py
@@ -234,6 +234,9 @@ class Athena(object):
 
     def start_query_execution(self, db, query):
         try:
+            if not db:
+                raise ValueError('Schema must be specified when session schema is not set')
+
             return self.athena.start_query_execution(
                 QueryString=query,
                 ClientRequestToken=str(uuid.uuid4()),
@@ -244,7 +247,7 @@ class Athena(object):
                     'OutputLocation': self.bucket
                 }
             )['QueryExecutionId']
-        except (ClientError, ParamValidationError) as e:
+        except (ClientError, ParamValidationError, ValueError) as e:
             print(e)
             return
 


### PR DESCRIPTION
```
$ athena
athena> show tables;
Schema must be specified when session schema is not set
athena> use sampledb;
athena:sampledb> show tables;
```