### PR TITLE
use full_parsed_statement when executing queries

### DIFF
--- a/athena_cli.py
+++ b/athena_cli.py
@@ -173,7 +173,7 @@ See http://docs.aws.amazon.com/athena/latest/ug/language-reference.html
         self.set_prompt()
 
     def default(self, statement):
-        self.athena.execution_id = self.athena.start_query_execution(self.dbname, statement)
+        self.athena.execution_id = self.athena.start_query_execution(self.dbname, statement.full_parsed_statement())
         if not self.athena.execution_id:
             return
 


### PR DESCRIPTION
@satterly 

thanks for the awesome work on this CLI! I ran into an issue on a fresh install where cmd2 will not include the full parsed statement in the argument for the default() function and instead recommends the use of full_parsed_statement ala https://github.com/python-cmd2/cmd2/blob/master/cmd2.py#L928

without this patch, all athena queries will fail as the first statement is stripped.