### PR TITLE
Support AWS_PROFILE environment variable for profile

### DIFF
--- a/athena_cli.py
+++ b/athena_cli.py
@@ -360,7 +360,7 @@ def main():
         sys.exit()
 
     # get profile
-    profile = args.profile or os.environ.get('AWS_DEFAULT_PROFILE', None)
+    profile = args.profile or os.environ.get('AWS_DEFAULT_PROFILE', None) or os.environ.get('AWS_PROFILE', None)
 
     # get region
     try:


### PR DESCRIPTION
awscli has switched to using AWS_PROFILE for default profile. boto3 doesn't support AWS_DEFAULT_PROFILE only AWS_PROFILE. athena-cli should support both.
