### PR TITLE
Fetch all results using paginator

### DIFF
--- a/athena_cli.py
+++ b/athena_cli.py
@@ -279,9 +279,17 @@ class Athena(object):
 
     def get_query_results(self, execution_id):
         try:
-            results = self.athena.get_query_results(
+            results = None
+            paginator = self.athena.get_paginator('get_query_results')
+            page_iterator = paginator.paginate(
                 QueryExecutionId=execution_id
             )
+
+            for page in page_iterator:
+                if results is None:
+                    results = page
+                else:
+                    results['ResultSet']['Rows'].extend(page['ResultSet']['Rows'])
         except ClientError as e:
             sys.exit(e)
 


### PR DESCRIPTION
At the moment athena-cli only yield results from the first page returned, so the limit of rows is 1000.

This MR adds [pagination](http://boto3.readthedocs.io/en/latest/guide/paginators.html) support to get the full list of results.