### PR TITLE
Cmd2 command-line parsing methods have changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
+cache: pip
+dist: xenial
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
+  - "3.6"
+  - "3.7"
 
 install:
-  - "pip install ."
   - "pip install -r requirements.txt"
+  - "pip install ."
 
 script: nosetests

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,6 @@
    Athena CLI
    Copyright 2017-2018 Guardian News & Media
+   Copyright 2019 Nick Satterly
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ License
 
     Athena CLI
     Copyright 2017-2018 Guardian News & Media
+    Copyright 2019 Nick Satterly
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/athena_cli.py
+++ b/athena_cli.py
@@ -64,12 +64,6 @@ class AthenaBatch(object):
         if status == 'FAILED':
             print(stats['QueryExecution']['Status']['StateChangeReason'])
 
-try:
-    del cmd.Cmd.do_show  # "show" is an Athena command
-except AttributeError:
-    # "show" was removed from Cmd2 0.8.0
-    pass
-
 
 class AthenaShell(cmd.Cmd, object):
 
@@ -179,7 +173,7 @@ See http://docs.aws.amazon.com/athena/latest/ug/language-reference.html
         super(AthenaShell, self).do_set(arg)
 
     def default(self, line):
-        self.execution_id = self.athena.start_query_execution(self.dbname, line.full_parsed_statement())
+        self.execution_id = self.athena.start_query_execution(self.dbname, line.command_and_args)
         if not self.execution_id:
             return
 

--- a/athena_cli.py
+++ b/athena_cli.py
@@ -349,8 +349,9 @@ def main():
     )
     parser.add_argument(
         '--output-format',
+        choices=('ALIGNED', 'VERTICAL', 'CSV', 'TSV', 'CSV_HEADER', 'TSV_HEADER', 'NULL'),
         dest='format',
-        help='output format for batch mode [ALIGNED, VERTICAL, CSV, TSV, CSV_HEADER, TSV_HEADER, NULL]'
+        help='output format for batch mode'
     )
     parser.add_argument(
         '--schema',

--- a/athena_cli.py
+++ b/athena_cli.py
@@ -43,13 +43,13 @@ class AthenaBatch(object):
 
         if status == 'SUCCEEDED':
             results = self.athena.get_query_results(execution_id)
-            headers = [h['Name'].encode("utf-8") for h in results['ResultSet']['ResultSetMetadata']['ColumnInfo']]
+            headers = [h['Name'] for h in results['ResultSet']['ResultSetMetadata']['ColumnInfo']]
 
             if self.format in ['CSV', 'CSV_HEADER']:
                 csv_writer = csv.writer(sys.stdout, quoting=csv.QUOTE_ALL)
                 if self.format == 'CSV_HEADER':
                     csv_writer.writerow(headers)
-                csv_writer.writerows([[text.encode("utf-8") for text in row] for row in self.athena.yield_rows(results, headers)])
+                csv_writer.writerows([row for row in self.athena.yield_rows(results, headers)])
             elif self.format == 'TSV':
                 print(tabulate([row for row in self.athena.yield_rows(results, headers)], tablefmt='tsv'))
             elif self.format == 'TSV_HEADER':

--- a/pypi.md
+++ b/pypi.md
@@ -1,7 +1,0 @@
-```
-$ python setup.py bdist_wheel --universal
-$ twine upload dist/athena_cli-0.0.x-py2.py3-none-any.whl
-```
-```
-$ python setup.py sdist bdist_wheel upload
-```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-boto3
-cmd2
-tabulate>=0.8.1
+boto3==1.9.145
+cmd2==0.9.12
+tabulate==0.8.3

--- a/setup.py
+++ b/setup.py
@@ -7,17 +7,17 @@ setup(
     name="athena-cli",
     version=version,
     description='Presto-like CLI for AWS Athena',
-    url='https://github.com/guardian/athena-cli',
+    url='https://github.com/satterly/athena-cli',
     license='Apache License 2.0',
     author='Nick Satterly',
-    author_email='nick.satterly@theguardian.com',
+    author_email='nick.satterly@gmail.com',
     packages=find_packages(),
     py_modules=[
         'athena_cli'
     ],
     install_requires=[
         'boto3',
-        'cmd2',
+        'cmd2>=0.9.0.1',
         'tabulate>=0.8.1'
     ],
     include_package_data=True,
@@ -30,5 +30,6 @@ setup(
     keywords='aws athena presto cli',
     classifiers=[
         'Topic :: Utilities'
-    ]
+    ],
+    python_requires='>=3.5'
 )


### PR DESCRIPTION
The method `Statement.full_parsed_statement()` in cmd2 version 0.8.x has been replaced with the attribute `Statement.command_and_args` in cmd2 version 0.9.x.

Additionally, cmd2 no longer supports Python 2.7 from version 0.9.x onwards.

Fixes #29 