### PR TITLE
Revert #21 to Fix CSV output for python 3

### DIFF
--- a/athena_cli.py
+++ b/athena_cli.py
@@ -43,13 +43,13 @@ class AthenaBatch(object):
 
         if status == 'SUCCEEDED':
             results = self.athena.get_query_results(execution_id)
-            headers = [h['Name'].encode("utf-8") for h in results['ResultSet']['ResultSetMetadata']['ColumnInfo']]
+            headers = [h['Name'] for h in results['ResultSet']['ResultSetMetadata']['ColumnInfo']]
 
             if self.format in ['CSV', 'CSV_HEADER']:
                 csv_writer = csv.writer(sys.stdout, quoting=csv.QUOTE_ALL)
                 if self.format == 'CSV_HEADER':
                     csv_writer.writerow(headers)
-                csv_writer.writerows([[text.encode("utf-8") for text in row] for row in self.athena.yield_rows(results, headers)])
+                csv_writer.writerows([row for row in self.athena.yield_rows(results, headers)])
             elif self.format == 'TSV':
                 print(tabulate([row for row in self.athena.yield_rows(results, headers)], tablefmt='tsv'))
             elif self.format == 'TSV_HEADER':


### PR DESCRIPTION
CSV output for Python 3 broke when applying a fix for CSV for Python 2.7.

Python 2.7 isn't supported anymore because cmd2 0.9 only supports Python 3 [#32] so we should just revert #21.

Fixes #33 and #31